### PR TITLE
Fix usages of syscall constants for Windows

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -131,7 +131,7 @@ impl Game {
 
     pub fn g_init(&mut self, level_time: i32, random_seed: i32, restart: bool) {
         self.call_vm([
-            GAME_INIT,
+            GAME_INIT as _,
             level_time as u32,
             random_seed as u32,
             restart as u32,
@@ -151,7 +151,7 @@ impl Game {
         is_bot: bool,
     ) -> Result<(), String> {
         let result = self.call_vm([
-            GAME_CLIENT_CONNECT,
+            GAME_CLIENT_CONNECT as _,
             client_num as u32,
             first_time as u32,
             is_bot as u32,
@@ -170,19 +170,52 @@ impl Game {
     }
 
     pub fn g_client_begin(&mut self, client_num: i32) {
-        self.call_vm([GAME_CLIENT_BEGIN, client_num as u32, 0, 0, 0, 0, 0, 0, 0, 0]);
+        self.call_vm([
+            GAME_CLIENT_BEGIN as _,
+            client_num as u32,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]);
     }
 
     pub fn g_client_think(&mut self, client_num: i32) {
-        self.call_vm([GAME_CLIENT_THINK, client_num as u32, 0, 0, 0, 0, 0, 0, 0, 0]);
+        self.call_vm([
+            GAME_CLIENT_THINK as _,
+            client_num as u32,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]);
     }
 
     pub fn g_run_frame(&mut self, level_time: i32) {
-        self.call_vm([GAME_RUN_FRAME, level_time as u32, 0, 0, 0, 0, 0, 0, 0, 0]);
+        self.call_vm([
+            GAME_RUN_FRAME as _,
+            level_time as u32,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]);
     }
 
     fn handle_syscall(&mut self, syscall: u32) {
-        match syscall {
+        match syscall as _ {
             G_PRINT => {
                 let s = self.vm.memory.cstr(self.vm.read_arg(0)).to_string_lossy();
                 println!("{s}");


### PR DESCRIPTION
AIUI, the default underlying type of a C enum in MSVC/Clang on Windows is `int`, regardless of whether there is a negative discriminant. Meanwhile, on other platforms Clang/GCC use `unsigned int` if it can.

This causes bindgen to use different types for the generated module constants, preventing it from compiling on Windows due to u32/i32 type mismatches[1]. While ugly, simply fixing it by casting to the appropriate type based on context for now...

[1] https://github.com/rust-lang/rust-bindgen/issues/1907